### PR TITLE
Prevent text-selection of nav btns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,6 +101,11 @@ footer {
   color: #0FA0CE;
   cursor: pointer;
   cursor: hand;
+  user-select: none;
+  -o-user-select:none;
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
 }
 
 


### PR DESCRIPTION
Looks ugly when people can select nav buttons that happen to be text.  This code disables that.
